### PR TITLE
VP-1554: Allow to use UpTree policy

### DIFF
--- a/src/VirtoCommerce.CatalogPersonalizationModule.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.CatalogPersonalizationModule.Core/ModuleConstants.cs
@@ -18,13 +18,6 @@ namespace VirtoCommerce.CatalogPersonalizationModule.Core
         {
             public static class General
             {
-                public static SettingDescriptor ExportImport = new SettingDescriptor
-                {
-                    Name = "CatalogPersonalization.ExportImport",
-                    GroupName = "Personalization|General",
-                    ValueType = SettingValueType.ShortText,
-                };                
-
                 public static SettingDescriptor TagsInheritancePolicy = new SettingDescriptor
                 {
                     Name = "CatalogPersonalization.TagsInheritancePolicy",
@@ -50,7 +43,6 @@ namespace VirtoCommerce.CatalogPersonalizationModule.Core
                     {
                         return new List<SettingDescriptor>
                         {
-                            ExportImport,
                             TagsInheritancePolicy,
                             CronExpression
                         };

--- a/src/VirtoCommerce.CatalogPersonalizationModule.Core/ModuleConstants.cs
+++ b/src/VirtoCommerce.CatalogPersonalizationModule.Core/ModuleConstants.cs
@@ -3,14 +3,14 @@ using VirtoCommerce.Platform.Core.Settings;
 
 namespace VirtoCommerce.CatalogPersonalizationModule.Core
 {
-    public class ModuleConstants
+    public static class ModuleConstants
     {
         public static class Security
         {
             public static class Permissions
             {
                 public const string Update = "personalization:update";
-                public static string[] AllPermissions = { Update };
+                public static readonly string[] AllPermissions = { Update };
             }
         }
 
@@ -18,7 +18,7 @@ namespace VirtoCommerce.CatalogPersonalizationModule.Core
         {
             public static class General
             {
-                public static SettingDescriptor TagsInheritancePolicy = new SettingDescriptor
+                public readonly static SettingDescriptor TagsInheritancePolicy = new SettingDescriptor
                 {
                     Name = "CatalogPersonalization.TagsInheritancePolicy",
                     GroupName = "Personalization|General",
@@ -28,7 +28,7 @@ namespace VirtoCommerce.CatalogPersonalizationModule.Core
                     RestartRequired = true
                 };
 
-                public static SettingDescriptor CronExpression = new SettingDescriptor
+                public readonly static SettingDescriptor CronExpression = new SettingDescriptor
                 {
                     Name = "CatalogPersonalization.CronExpression",
                     GroupName = "Personalization|General",

--- a/src/VirtoCommerce.CatalogPersonalizationModule.Data/Repositories/IPersonalizationRepository.cs
+++ b/src/VirtoCommerce.CatalogPersonalizationModule.Data/Repositories/IPersonalizationRepository.cs
@@ -1,5 +1,5 @@
-using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
 using VirtoCommerce.CatalogPersonalizationModule.Data.Model;
 using VirtoCommerce.Platform.Core.Common;
 
@@ -7,9 +7,9 @@ namespace VirtoCommerce.CatalogPersonalizationModule.Data.Repositories
 {
     public interface IPersonalizationRepository : IRepository
     {
-        IQueryable<TaggedItemEntity> TaggedItems { get; }
-        IQueryable<TagEntity> Tags { get; }
-        IQueryable<TaggedItemOutlineEntity> TaggedItemOutlines { get; }
+        DbSet<TaggedItemEntity> TaggedItems { get; }
+        DbSet<TagEntity> Tags { get; }
+        DbSet<TaggedItemOutlineEntity> TaggedItemOutlines { get; }
 
         Task<TaggedItemEntity[]> GetTaggedItemsByIdsAsync(string[] ids, string responseGroup);
         Task DeleteTaggedItemsAsync(string[] ids);

--- a/src/VirtoCommerce.CatalogPersonalizationModule.Data/Repositories/IPersonalizationRepository.cs
+++ b/src/VirtoCommerce.CatalogPersonalizationModule.Data/Repositories/IPersonalizationRepository.cs
@@ -1,5 +1,5 @@
+using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore;
 using VirtoCommerce.CatalogPersonalizationModule.Data.Model;
 using VirtoCommerce.Platform.Core.Common;
 
@@ -7,11 +7,12 @@ namespace VirtoCommerce.CatalogPersonalizationModule.Data.Repositories
 {
     public interface IPersonalizationRepository : IRepository
     {
-        DbSet<TaggedItemEntity> TaggedItems { get; }
-        DbSet<TagEntity> Tags { get; }
-        DbSet<TaggedItemOutlineEntity> TaggedItemOutlines { get; }
+        IQueryable<TaggedItemEntity> TaggedItems { get; }
+        IQueryable<TagEntity> Tags { get; }
+        IQueryable<TaggedItemOutlineEntity> TaggedItemOutlines { get; }
 
         Task<TaggedItemEntity[]> GetTaggedItemsByIdsAsync(string[] ids, string responseGroup);
         Task DeleteTaggedItemsAsync(string[] ids);
+        Task<TaggedItemOutlineEntity[]> GetTaggedItemOutlinesInsideOutlinesAsync(string[] outlines);
     }
 }

--- a/src/VirtoCommerce.CatalogPersonalizationModule.Data/Repositories/PersonalizationRepository.cs
+++ b/src/VirtoCommerce.CatalogPersonalizationModule.Data/Repositories/PersonalizationRepository.cs
@@ -14,15 +14,15 @@ namespace VirtoCommerce.CatalogPersonalizationModule.Data.Repositories
 {
     public class PersonalizationRepository : DbContextRepositoryBase<PersonalizationDbContext>, IPersonalizationRepository
     {
-        public PersonalizationRepository(PersonalizationDbContext dbContext): base(dbContext)
+        public PersonalizationRepository(PersonalizationDbContext dbContext) : base(dbContext)
         {
         }
 
-        public IQueryable<TaggedItemEntity> TaggedItems => DbContext.Set<TaggedItemEntity>().Include(x => x.Tags);
+        public DbSet<TaggedItemEntity> TaggedItems => DbContext.Set<TaggedItemEntity>();
 
-        public IQueryable<TagEntity> Tags => DbContext.Set<TagEntity>();
+        public DbSet<TagEntity> Tags => DbContext.Set<TagEntity>();
 
-        public IQueryable<TaggedItemOutlineEntity> TaggedItemOutlines => DbContext.Set<TaggedItemOutlineEntity>();
+        public DbSet<TaggedItemOutlineEntity> TaggedItemOutlines => DbContext.Set<TaggedItemOutlineEntity>();
 
         public async Task<TaggedItemEntity[]> GetTaggedItemsByIdsAsync(string[] ids, string responseGroup)
         {
@@ -31,7 +31,7 @@ namespace VirtoCommerce.CatalogPersonalizationModule.Data.Repositories
             {
                 var taggedItemsGroup = EnumUtility.SafeParse(responseGroup, TaggedItemResponseGroup.Full);
 
-                result = await TaggedItems.Where(x => ids.Contains(x.Id)).ToArrayAsync();
+                result = await TaggedItems.Include(x => x.Tags).Where(x => ids.Contains(x.Id)).ToArrayAsync();
 
                 if (taggedItemsGroup.HasFlag(TaggedItemResponseGroup.WithOutlines))
                 {

--- a/src/VirtoCommerce.CatalogPersonalizationModule.Data/Repositories/PersonalizationRepository.cs
+++ b/src/VirtoCommerce.CatalogPersonalizationModule.Data/Repositories/PersonalizationRepository.cs
@@ -31,7 +31,7 @@ namespace VirtoCommerce.CatalogPersonalizationModule.Data.Repositories
             {
                 var taggedItemsGroup = EnumUtility.SafeParse(responseGroup, TaggedItemResponseGroup.Full);
 
-                result = await TaggedItems.Include(x => x.Tags).Where(x => ids.Contains(x.Id)).ToArrayAsync();
+                result = await TaggedItems.Where(x => ids.Contains(x.Id)).ToArrayAsync();
 
                 if (taggedItemsGroup.HasFlag(TaggedItemResponseGroup.WithOutlines))
                 {

--- a/src/VirtoCommerce.CatalogPersonalizationModule.Data/Services/PersonalizationService.cs
+++ b/src/VirtoCommerce.CatalogPersonalizationModule.Data/Services/PersonalizationService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using VirtoCommerce.CatalogPersonalizationModule.Core.Model;
 using VirtoCommerce.CatalogPersonalizationModule.Core.Model.Search;
@@ -48,7 +49,7 @@ namespace VirtoCommerce.CatalogPersonalizationModule.Data.Services
                     {
                         repository.DisableChangesTracking();
 
-                        var query = repository.TaggedItems;
+                        IQueryable<TaggedItemEntity> query = repository.TaggedItems.Include(x => x.Tags);
 
                         if (!criteria.EntityIds.IsNullOrEmpty())
                         {
@@ -172,7 +173,7 @@ namespace VirtoCommerce.CatalogPersonalizationModule.Data.Services
 
                 foreach (var taggedItem in result)
                 {
-                    var entities = await _taggedEntitiesServiceFactory.Create(taggedItem.EntityType).GetEntitiesByIdsAsync(new[] {taggedItem.EntityId});
+                    var entities = await _taggedEntitiesServiceFactory.Create(taggedItem.EntityType).GetEntitiesByIdsAsync(new[] { taggedItem.EntityId });
                     var evaluatedItems = await EvaluateEffectiveTags(entities.ToList());
 
                     taggedItem.InheritedTags = evaluatedItems.FirstOrDefault(x => x.EntityId == taggedItem.EntityId)?.InheritedTags;
@@ -183,7 +184,7 @@ namespace VirtoCommerce.CatalogPersonalizationModule.Data.Services
 
             if (!entityIdsWithoutAssignedTags.IsNullOrEmpty())
             {
-                var entityTypesWithInheritance = new[] {KnownDocumentTypes.Product, KnownDocumentTypes.Category};
+                var entityTypesWithInheritance = new[] { KnownDocumentTypes.Product, KnownDocumentTypes.Category };
                 var entitiesWithoutAssignedTags = new List<IEntity>();
 
                 foreach (var entityType in entityTypesWithInheritance)

--- a/src/VirtoCommerce.CatalogPersonalizationModule.Data/Services/PersonalizationService.cs
+++ b/src/VirtoCommerce.CatalogPersonalizationModule.Data/Services/PersonalizationService.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using VirtoCommerce.CatalogPersonalizationModule.Core.Model;
 using VirtoCommerce.CatalogPersonalizationModule.Core.Model.Search;
@@ -49,7 +48,7 @@ namespace VirtoCommerce.CatalogPersonalizationModule.Data.Services
                     {
                         repository.DisableChangesTracking();
 
-                        IQueryable<TaggedItemEntity> query = repository.TaggedItems.Include(x => x.Tags);
+                        var query = repository.TaggedItems;
 
                         if (!criteria.EntityIds.IsNullOrEmpty())
                         {

--- a/src/VirtoCommerce.CatalogPersonalizationModule.Data/Services/PersonalizationService.cs
+++ b/src/VirtoCommerce.CatalogPersonalizationModule.Data/Services/PersonalizationService.cs
@@ -172,7 +172,7 @@ namespace VirtoCommerce.CatalogPersonalizationModule.Data.Services
 
                 foreach (var taggedItem in result)
                 {
-                    var entities = await _taggedEntitiesServiceFactory.Create(taggedItem.EntityType).GetEntitiesByIdsAsync(new[] { taggedItem.EntityId });
+                    var entities = await _taggedEntitiesServiceFactory.Create(taggedItem.EntityType).GetEntitiesByIdsAsync(new[] {taggedItem.EntityId});
                     var evaluatedItems = await EvaluateEffectiveTags(entities.ToList());
 
                     taggedItem.InheritedTags = evaluatedItems.FirstOrDefault(x => x.EntityId == taggedItem.EntityId)?.InheritedTags;
@@ -183,7 +183,7 @@ namespace VirtoCommerce.CatalogPersonalizationModule.Data.Services
 
             if (!entityIdsWithoutAssignedTags.IsNullOrEmpty())
             {
-                var entityTypesWithInheritance = new[] { KnownDocumentTypes.Product, KnownDocumentTypes.Category };
+                var entityTypesWithInheritance = new[] {KnownDocumentTypes.Product, KnownDocumentTypes.Category};
                 var entitiesWithoutAssignedTags = new List<IEntity>();
 
                 foreach (var entityType in entityTypesWithInheritance)

--- a/src/VirtoCommerce.CatalogPersonalizationModule.Web/Localizations/en.VirtoCommerce.CatalogPersonalization.json
+++ b/src/VirtoCommerce.CatalogPersonalizationModule.Web/Localizations/en.VirtoCommerce.CatalogPersonalization.json
@@ -38,10 +38,6 @@
     },
     "settings": {
       "CatalogPersonalization": {
-        "ExportImport": {
-          "description": "Module description in platform export/import wizard",
-          "title": "Export/Import description"
-        },
         "TagsInheritancePolicy": {
           "description": "DownTree - propagates all tags assigned to categories for all their descendants. UpTree - propagates tags up to hierarchy from descendants to parents",
           "title": "Selected policy for tags propagation (requires restart)"
@@ -54,7 +50,7 @@
      },
     "module": {
       "VirtoCommerce.CatalogPersonalization": {
-        "description": "Personalization feature for the products and categories."
+        "description": "Export/Import tagged items"
       }
     },
     "permissions": {

--- a/src/VirtoCommerce.CatalogPersonalizationModule.Web/Module.cs
+++ b/src/VirtoCommerce.CatalogPersonalizationModule.Web/Module.cs
@@ -1,15 +1,14 @@
-using Hangfire;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Hangfire;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using VirtoCommerce.CatalogModule.Core.Search;
-using VirtoCommerce.CatalogModule.Core.Services;
 using VirtoCommerce.CatalogPersonalizationModule.Core;
 using VirtoCommerce.CatalogPersonalizationModule.Core.Services;
 using VirtoCommerce.CatalogPersonalizationModule.Data.Repositories;
@@ -36,7 +35,7 @@ namespace VirtoCommerce.CatalogPersonalizationModule.Web
 
         public void Initialize(IServiceCollection serviceCollection)
         {
-            
+
             var configuration = serviceCollection.BuildServiceProvider().GetRequiredService<IConfiguration>();
             serviceCollection.AddTransient<IPersonalizationRepository, PersonalizationRepository>();
             var connectionString = configuration.GetConnectionString("VirtoCommerce");
@@ -54,16 +53,16 @@ namespace VirtoCommerce.CatalogPersonalizationModule.Web
             serviceCollection.AddSingleton<TaggedItemIndexChangesProvider>();
             serviceCollection.AddSingleton<ProductTaggedItemDocumentBuilder>();
             serviceCollection.AddSingleton<CategoryTaggedItemDocumentBuilder>();
-            
+
             serviceCollection.AddSingleton<PersonalizationExportImport>();
-            
+
             serviceCollection.AddTransient<ITagPropagationPolicy>(provider =>
             {
                 var settingsManager = provider.GetService<ISettingsManager>();
                 var repositoryFactory = provider.GetService<Func<IPersonalizationRepository>>();
                 var listEntrySearchService = provider.GetService<IListEntrySearchService>();
-                
-                var tagsInheritancePolicy = settingsManager.GetValue("VirtoCommerce.Personalization.TagsInheritancePolicy", "DownTree");
+
+                var tagsInheritancePolicy = settingsManager.GetValue(ModuleConstants.Settings.General.TagsInheritancePolicy.Name, "DownTree");
                 if (tagsInheritancePolicy.EqualsInvariant("DownTree"))
                 {
                     return new DownTreeTagPropagationPolicy(repositoryFactory);


### PR DESCRIPTION
- Used propert setting to select policy;
- Used raw SQL query to get tagged items that are located inside  the category;
- Fixed bug with '__any' tag (Everyone) group was not calculated for any category;
- Fixed export localization description;