### PR TITLE
VP-5207: Handle TaggedItem duplicates

### DIFF
--- a/src/VirtoCommerce.CatalogPersonalizationModule.Data/Migrations/20200914134605_AddTaggedItemUniqueIndex.cs
+++ b/src/VirtoCommerce.CatalogPersonalizationModule.Data/Migrations/20200914134605_AddTaggedItemUniqueIndex.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace VirtoCommerce.CatalogPersonalizationModule.Data.Migrations
 {
@@ -6,6 +6,62 @@ namespace VirtoCommerce.CatalogPersonalizationModule.Data.Migrations
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            migrationBuilder.Sql(@"
+	            -- 1. Set Tag.TaggedItemId to one element in all tags belonging to one ObjectId using different tag items
+	            ;WITH TagDuplicates (Id, TaggedItemId, first_tagged_item_id, tagged_item_row_num) AS (
+		            SELECT 
+			            t.Id,
+			            t.TaggedItemId,
+			            FIRST_VALUE(t.TaggedItemId) OVER(
+				            PARTITION BY 
+					            [ObjectId], 
+					            [ObjectType]
+				            ORDER BY 
+					            [ObjectId], 
+					            [ObjectType],
+					            t.TaggedItemId
+			            ) as first_tagged_item_id,
+			            ROW_NUMBER() OVER (
+				            PARTITION BY 
+					            [ObjectId], 
+					            [ObjectType]
+				            ORDER BY 
+					            [ObjectId], 
+					            [ObjectType]
+			            ) tagged_item_row_num
+			            FROM [TaggedItem] ti 
+			            INNER JOIN [Tag] t ON ti.Id = t.TaggedItemId
+	            )
+	            UPDATE t
+	            SET 
+		            t.TaggedItemId = TagDuplicates.first_tagged_item_id
+	            FROM Tag t INNER JOIN TagDuplicates ON t.Id = TagDuplicates.Id		
+	            WHERE tagged_item_row_num > 1;
+
+	            -- 2. Delete Tag duplicates
+	            ;WITH cte AS (
+		            SELECT 
+			            Tag, 
+			            TaggedItemId, 
+			            ROW_NUMBER() OVER (
+				            PARTITION BY 
+					            Tag, 
+					            TaggedItemId
+				            ORDER BY 
+					            Tag, 
+					            TaggedItemId
+			            ) row_num
+			            FROM 
+			            [Tag]
+	            )
+	            DELETE FROM cte
+	            WHERE row_num > 1;
+
+	            -- 3. Delete empty TaggedItem's (former duplicates without Tags now)
+	            DELETE FROM [TaggedItem]
+	            WHERE NOT EXISTS (SELECT 1 FROM [Tag] Where [TaggedItem].Id = [Tag].TaggedItemId);
+            ");
+
             migrationBuilder.CreateIndex(
                 name: "IX_ObjectId_ObjectType",
                 table: "TaggedItem",

--- a/src/VirtoCommerce.CatalogPersonalizationModule.Data/Migrations/20200914134605_AddTaggedItemUniqueIndex.cs
+++ b/src/VirtoCommerce.CatalogPersonalizationModule.Data/Migrations/20200914134605_AddTaggedItemUniqueIndex.cs
@@ -8,7 +8,7 @@ namespace VirtoCommerce.CatalogPersonalizationModule.Data.Migrations
         {
             migrationBuilder.Sql(@"
 	            -- 1. Set Tag.TaggedItemId to one element in all tags belonging to one ObjectId using different tag items
-	            ;WITH TagDuplicates (Id, TaggedItemId, first_tagged_item_id, tagged_item_row_num) AS (
+	            ;WITH TagDuplicates (Id, TaggedItemId, first_tagged_item_id) AS (
 		            SELECT 
 			            t.Id,
 			            t.TaggedItemId,
@@ -17,18 +17,8 @@ namespace VirtoCommerce.CatalogPersonalizationModule.Data.Migrations
 					            [ObjectId], 
 					            [ObjectType]
 				            ORDER BY 
-					            [ObjectId], 
-					            [ObjectType],
 					            t.TaggedItemId
-			            ) as first_tagged_item_id,
-			            ROW_NUMBER() OVER (
-				            PARTITION BY 
-					            [ObjectId], 
-					            [ObjectType]
-				            ORDER BY 
-					            [ObjectId], 
-					            [ObjectType]
-			            ) tagged_item_row_num
+			            ) as first_tagged_item_id
 			            FROM [TaggedItem] ti 
 			            INNER JOIN [Tag] t ON ti.Id = t.TaggedItemId
 	            )
@@ -36,7 +26,7 @@ namespace VirtoCommerce.CatalogPersonalizationModule.Data.Migrations
 	            SET 
 		            t.TaggedItemId = TagDuplicates.first_tagged_item_id
 	            FROM Tag t INNER JOIN TagDuplicates ON t.Id = TagDuplicates.Id		
-	            WHERE tagged_item_row_num > 1;
+	            WHERE t.TaggedItemId <> first_tagged_item_id;
 
 	            -- 2. Delete Tag duplicates
 	            ;WITH cte AS (
@@ -48,8 +38,7 @@ namespace VirtoCommerce.CatalogPersonalizationModule.Data.Migrations
 					            Tag, 
 					            TaggedItemId
 				            ORDER BY 
-					            Tag, 
-					            TaggedItemId
+					            [Id]
 			            ) row_num
 			            FROM 
 			            [Tag]


### PR DESCRIPTION
Add the script into existing migration with adding unique index on ObjectId,ObjectType, which links all tags for one ObjectId to the one TaggedItem, and remove duplicated TaggedItems.