### PR TITLE
VCST-5163: Stable 15 — CatalogPersonalization (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.CatalogPersonalizationModule.Core/VirtoCommerce.CatalogPersonalizationModule.Core.csproj
+++ b/src/VirtoCommerce.CatalogPersonalizationModule.Core/VirtoCommerce.CatalogPersonalizationModule.Core.csproj
@@ -10,6 +10,6 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.CatalogPersonalizationModule.Data.MySql/VirtoCommerce.CatalogPersonalizationModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.CatalogPersonalizationModule.Data.MySql/VirtoCommerce.CatalogPersonalizationModule.Data.MySql.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CatalogPersonalizationModule.Data\VirtoCommerce.CatalogPersonalizationModule.Data.csproj" />

--- a/src/VirtoCommerce.CatalogPersonalizationModule.Data.PostgreSql/VirtoCommerce.CatalogPersonalizationModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.CatalogPersonalizationModule.Data.PostgreSql/VirtoCommerce.CatalogPersonalizationModule.Data.PostgreSql.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CatalogPersonalizationModule.Data\VirtoCommerce.CatalogPersonalizationModule.Data.csproj" />

--- a/src/VirtoCommerce.CatalogPersonalizationModule.Data.SqlServer/VirtoCommerce.CatalogPersonalizationModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.CatalogPersonalizationModule.Data.SqlServer/VirtoCommerce.CatalogPersonalizationModule.Data.SqlServer.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CatalogPersonalizationModule.Data\VirtoCommerce.CatalogPersonalizationModule.Data.csproj" />

--- a/src/VirtoCommerce.CatalogPersonalizationModule.Data/VirtoCommerce.CatalogPersonalizationModule.Data.csproj
+++ b/src/VirtoCommerce.CatalogPersonalizationModule.Data/VirtoCommerce.CatalogPersonalizationModule.Data.csproj
@@ -10,10 +10,10 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.CatalogModule.Data" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1007.10" />
-    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.CatalogModule.Data" Version="3.1029.0" />
+    <PackageReference Include="VirtoCommerce.CoreModule.Core" Version="3.1007.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1039.0" />
+    <PackageReference Include="VirtoCommerce.SearchModule.Core" Version="3.1004.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CatalogPersonalizationModule.Core\VirtoCommerce.CatalogPersonalizationModule.Core.csproj" />

--- a/src/VirtoCommerce.CatalogPersonalizationModule.Web/ExportImport/PersonalizationExportImport.cs
+++ b/src/VirtoCommerce.CatalogPersonalizationModule.Web/ExportImport/PersonalizationExportImport.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+
 using System.Threading;
 using System.IO;
 using System.Linq;
@@ -35,8 +36,8 @@ namespace VirtoCommerce.CatalogPersonalizationModule.Web.ExportImport
             using (var sw = new StreamWriter(outStream, System.Text.Encoding.UTF8))
             using (var writer = new JsonTextWriter(sw))
             {
-                await writer.WriteStartObjectAsync();
-                await writer.WritePropertyNameAsync("TaggedItems");
+                await writer.WriteStartObjectAsync(cancellationToken);
+                await writer.WritePropertyNameAsync("TaggedItems", cancellationToken);
 
                 await writer.SerializeArrayWithPagingAsync(_serializer, _batchSize, async (skip, take) =>
                         (GenericSearchResult<TaggedItem>)await _taggedItemSearchService.SearchTaggedItemsAsync(new TaggedItemSearchCriteria { Skip = skip, Take = take })
@@ -46,8 +47,8 @@ namespace VirtoCommerce.CatalogPersonalizationModule.Web.ExportImport
                         progressCallback(progressInfo);
                     }, cancellationToken);
 
-                await writer.WriteEndObjectAsync();
-                await writer.FlushAsync();
+                await writer.WriteEndObjectAsync(cancellationToken);
+                await writer.FlushAsync(cancellationToken);
             }
         }
 
@@ -61,7 +62,7 @@ namespace VirtoCommerce.CatalogPersonalizationModule.Web.ExportImport
             using (var streamReader = new StreamReader(inputStream))
             using (var reader = new JsonTextReader(streamReader))
             {
-                while (await reader.ReadAsync())
+                while (await reader.ReadAsync(cancellationToken))
                 {
                     if (reader.TokenType != JsonToken.PropertyName)
                     {

--- a/src/VirtoCommerce.CatalogPersonalizationModule.Web/ExportImport/PersonalizationExportImport.cs
+++ b/src/VirtoCommerce.CatalogPersonalizationModule.Web/ExportImport/PersonalizationExportImport.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+using System.Threading;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -25,7 +26,7 @@ namespace VirtoCommerce.CatalogPersonalizationModule.Web.ExportImport
             _serializer = jsonSerializer;
         }
 
-        public async Task DoExportAsync(Stream outStream, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+        public async Task DoExportAsync(Stream outStream, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             var progressInfo = new ExportImportProgressInfo { Description = "loading data..." };
@@ -50,7 +51,7 @@ namespace VirtoCommerce.CatalogPersonalizationModule.Web.ExportImport
             }
         }
 
-        public async Task DoImportAsync(Stream inputStream, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+        public async Task DoImportAsync(Stream inputStream, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/VirtoCommerce.CatalogPersonalizationModule.Web/Module.cs
+++ b/src/VirtoCommerce.CatalogPersonalizationModule.Web/Module.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+using System.Threading;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -177,12 +178,12 @@ namespace VirtoCommerce.CatalogPersonalizationModule.Web
             throw new NotImplementedException();
         }
 
-        public async Task ExportAsync(Stream outStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+        public async Task ExportAsync(Stream outStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
         {
             await _appBuilder.ApplicationServices.GetRequiredService<PersonalizationExportImport>().DoExportAsync(outStream, progressCallback, cancellationToken);
         }
 
-        public async Task ImportAsync(Stream inputStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback, ICancellationToken cancellationToken)
+        public async Task ImportAsync(Stream inputStream, ExportImportOptions options, Action<ExportImportProgressInfo> progressCallback, CancellationToken cancellationToken)
         {
             await _appBuilder.ApplicationServices.GetRequiredService<PersonalizationExportImport>().DoImportAsync(inputStream, progressCallback, cancellationToken);
         }

--- a/src/VirtoCommerce.CatalogPersonalizationModule.Web/VirtoCommerce.CatalogPersonalizationModule.Web.csproj
+++ b/src/VirtoCommerce.CatalogPersonalizationModule.Web/VirtoCommerce.CatalogPersonalizationModule.Web.csproj
@@ -7,7 +7,7 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1007.10" />
+    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CatalogPersonalizationModule.Core\VirtoCommerce.CatalogPersonalizationModule.Core.csproj" />

--- a/src/VirtoCommerce.CatalogPersonalizationModule.Web/module.manifest
+++ b/src/VirtoCommerce.CatalogPersonalizationModule.Web/module.manifest
@@ -4,11 +4,11 @@
   <version>3.1003.0</version>
   <version-tag />
 
-  <platformVersion>3.1007.10</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Catalog" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Core" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Search" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Catalog" version="3.1029.0" />
+    <dependency id="VirtoCommerce.Core" version="3.1007.0" />
+    <dependency id="VirtoCommerce.Search" version="3.1004.0" />
   </dependencies>
 
   <title>Catalog Personalization</title>

--- a/tests/VirtoCommerce.CatalogPersonalizationModule.Test/VirtoCommerce.CatalogPersonalizationModule.Test.csproj
+++ b/tests/VirtoCommerce.CatalogPersonalizationModule.Test/VirtoCommerce.CatalogPersonalizationModule.Test.csproj
@@ -4,7 +4,7 @@
     <noWarn>1591;NU1608</noWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Part of **Stable 15** (Wave 5). Builds against published platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) + Wave 1–4 packages on nuget.org. Version handled by CI.

- ICancellationToken→CancellationToken migration.
- `vc-build Compress` green incl. unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version bumps and a mechanical cancellation-token signature migration on export/import; no new business logic or security-sensitive behavior.
> 
> **Overview**
> Aligns the module with **Stable 15** by bumping Virto Commerce platform and related module packages (platform **3.1039.0**, Catalog, Core, Search, and DB provider packages) in project files and `module.manifest`.
> 
> **Export/import** is updated for the platform API change: `ICancellationToken` is replaced with `System.Threading.CancellationToken` on `Module` export/import entry points and `PersonalizationExportImport`, and JSON writer/reader async calls now pass the token through.
> 
> Test tooling bumps `coverlet.collector` from 8.0.1 to 10.0.1.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07edffdf214414ee8c4557aa3a2cac75b495bb4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.CatalogPersonalization_3.1003.0-pr-89-07ed.zip